### PR TITLE
Extra test should invalidate sub-word count.

### DIFF
--- a/verification/tests.py
+++ b/verification/tests.py
@@ -24,11 +24,11 @@ TESTS = {
     ],
     "Extra": [
         {
-            "input": [TEXT, ['one', 'two', 'three']],
+            "input": [TEXT2, ['as', 'i', 'it']],
             "answer": {
-                'one': 1,
-                'two': 1,
-                'three': 0
+                'as': 2,
+                'i': 2,
+                'it': 2
             }
         },
         {


### PR DESCRIPTION
As noted at https://py.checkio.org/mission/popular-words/publications/CTimmerman/python-3/first/#comment-57977, any 2+ letter word with an I in it would count as the word I using the code that passed as my first publication using `text = text.lower()`.

I would not count "it's" as a word, but whatever.