### PR TITLE
Case sensitive testing

### DIFF
--- a/verification/tests.py
+++ b/verification/tests.py
@@ -67,6 +67,15 @@ TESTS = {
                 "will": 2,
                 "no": 1
             }
+        },
+        {
+            "input": [TEXT, ['I', 'wAs', 'ThReE', 'NeAr']],
+            "answer": {
+                'I': 4,
+                'wAs': 3,
+                'ThReE': 0,
+                'NeAr': 0
+            }
         }
     ]
 }


### PR DESCRIPTION
Not sure why, but the tests wasn't considering case sensitiveness, as described on Task Description.
Added the same "Basics" test, but with upper and lower cases.